### PR TITLE
Update flask version.

### DIFF
--- a/flask/helloworld/requirements.txt
+++ b/flask/helloworld/requirements.txt
@@ -1,2 +1,2 @@
-Flask==1.1.2
+Flask==2.2.2
 flask-cors==3.0.9


### PR DESCRIPTION
Update flask version to prevent from the following error message [Yesterday 2:46 PM] Keegan DSouza
 

If you are receiving this error.   from jinja2 import escape
ImportError: cannot import name 'escape' from 'jinja2' (/usr/local/lib/python3.8/site-packages/jinja2/__init__.py)